### PR TITLE
remove run-at decleration

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -6,7 +6,6 @@
 // @license      Apache-2.0; http://www.apache.org/licenses/LICENSE-2.0.txt
 // @match        *://*.bandcamp.com/album/*
 // @match        *://*.bandcamp.com/track/*
-// @run-at       document-start
 // @namespace    https://github.com/Redcrafter
 // ==/UserScript==
 

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,6 @@
 // @license      Apache-2.0; http://www.apache.org/licenses/LICENSE-2.0.txt
 // @match        *://*.bandcamp.com/album/*
 // @match        *://*.bandcamp.com/track/*
-// @run-at       document-start
 // @namespace    https://github.com/Redcrafter
 // ==/UserScript==
 


### PR DESCRIPTION
due to https://github.com/greasemonkey/greasemonkey/issues/2515 this statement breaks the head injections on line 15 and 19. the script does not appear to require running at document start, and works fine with the default (document-end)